### PR TITLE
SUBARRAY: Added longest non-decreasing subsequence functionality

### DIFF
--- a/src/main/java/interviewbit_greedy/SubarrayQuestions.java
+++ b/src/main/java/interviewbit_greedy/SubarrayQuestions.java
@@ -1,0 +1,30 @@
+package interviewbit_greedy;
+
+public class SubarrayQuestions {
+
+    /**
+     * Determines the longest subarray in an input array where all elements of the subarray are non decreasing.
+     *
+     * @param inputArray - an int array
+     * @return the longest subarray as described above
+     */
+
+    public int longestSubsequenceDetermination(int[] inputArray) {
+        if (inputArray != null && inputArray.length > 0) {
+            int[] longestArray = new int[inputArray.length];
+
+            for (int i = longestArray.length - 1; i >= 0; i--) {
+                longestArray[i]=1;
+
+                for (int j = i+1; j < longestArray.length; j++) {
+                    if (inputArray[i]<=inputArray[j]) {
+                        longestArray[i] = Math.max(longestArray[i], longestArray[j]+1);
+                    }
+                }
+            }
+            return longestArray[0];
+        }
+        return 0;
+
+    }
+}

--- a/src/test/java/interviewbit_greedy/SubarrayQuestionsTest.java
+++ b/src/test/java/interviewbit_greedy/SubarrayQuestionsTest.java
@@ -1,0 +1,34 @@
+package interviewbit_greedy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SubarrayQuestionsTest {
+    
+    private SubarrayQuestions subarrayQuestions;
+
+    private final int[] LONG_SEQ_TEST_1_BASE = {1, 1, 3, 2, 6, 7, 1};
+    private final int[] LONG_SEQ_TEST_2_EMPTY = {};
+    private final int[] LONG_SEQ_TEST_3_ONE_ELM = {1};
+    private final int[] LONG_SEQ_TEST_4_INTERLEAVE = {1, 1, 13, 2, 4, 5, 16, 18, 11};
+
+    @BeforeEach
+    void init() {
+        subarrayQuestions = new SubarrayQuestions();
+    }
+    
+    @Test
+    void longestSubsequenceDeterminationTest() {
+        assertEquals(5, subarrayQuestions.longestSubsequenceDetermination(LONG_SEQ_TEST_1_BASE),
+                "Test 1 - Base");
+        assertEquals(0, subarrayQuestions.longestSubsequenceDetermination(LONG_SEQ_TEST_2_EMPTY),
+                "Test 2 - Empty");
+        assertEquals(1, subarrayQuestions.longestSubsequenceDetermination(LONG_SEQ_TEST_3_ONE_ELM),
+                "Test 3 - One Element");
+        assertEquals(7, subarrayQuestions.longestSubsequenceDetermination(LONG_SEQ_TEST_4_INTERLEAVE),
+                "Test 4 - Interleaved");
+
+    }
+}


### PR DESCRIPTION
Implemented O(n^2) solution to Longest Subsequence problem (https://www.interviewbit.com/problems/longest-increasing-subsequence/).

Struggled for a while trying to get this to O(n log(n)) but since the largest subsequence array downstream of index i will not necessarily be the smallest number following A[i] nor the largest subsequence after i, I don't know if it's possible. It seems to be without going into formal proof that in order to guarantee the largest subsequence is found containing some index i, all indices downstream of i would need to be consulted.